### PR TITLE
OSX wine pyinstaller PATH fix.

### DIFF
--- a/Dr0p1t.py
+++ b/Dr0p1t.py
@@ -43,7 +43,11 @@ def PyInstaller():
     if os.name=="nt":
         installer = "pyinstaller"
     else:
-        installer = "wine /root/.wine/drive_c/Python27/python.exe /root/.wine/drive_c/Python27/Scripts/pyinstaller-script.py"
+        if sys.platform == "darwin": # On osx, the default .wine directory is located on $HOME/.wine/
+            installer = "wine " + os.environ['HOME'] + "/.wine/drive_c/Python27/python.exe " + os.environ['HOME'] + "/.wine/drive_c/Python27/Scripts/pyinstaller-script.py"
+        else: # TODO: find all defaults location for .wine , or request it directely to the user if not found.
+            installer = "wine /root/.wine/drive_c/Python27/python.exe /root/.wine/drive_c/Python27/Scripts/pyinstaller-script.py"
+
     p = subprocess.Popen( installer + " -h",shell=True,stdout=subprocess.PIPE,stderr=subprocess.PIPE )
     x = p.stdout.read().decode()
     if x == "":

--- a/Dr0p1t.py
+++ b/Dr0p1t.py
@@ -101,7 +101,7 @@ def main():
 
     if not args.q:
         banner()
-    
+
     if os.name=="nt":
         installer = "pyinstaller"
         exe = ""

--- a/Dr0p1t.py
+++ b/Dr0p1t.py
@@ -101,12 +101,15 @@ def main():
 
     if not args.q:
         banner()
-
+    
     if os.name=="nt":
         installer = "pyinstaller"
         exe = ""
     else:
-        installer = "wine /root/.wine/drive_c/Python27/python.exe /root/.wine/drive_c/Python27/Scripts/pyinstaller-script.py"
+        if sys.platform == "darwin": # On osx, the default .wine directory is located on $HOME/.wine/
+            installer = "wine " + os.environ['HOME'] + "/.wine/drive_c/Python27/python.exe " + os.environ['HOME'] + "/.wine/drive_c/Python27/Scripts/pyinstaller-script.py"
+        else: # TODO: find all defaults location for .wine , or request it directely to the user if not found.
+            installer = "wine /root/.wine/drive_c/Python27/python.exe /root/.wine/drive_c/Python27/Scripts/pyinstaller-script.py"
         exe = "wine "
 
     url      = args.url


### PR DESCRIPTION
In fact, .wine is located at $HOME/.wine/ on OSX ( before, if os.name != "nt": installer = "wine /root/.wine[...]" )...
So now, PyInstaller() would return ```true``` on mac, if pyinstaller is installed inside wine ^^.